### PR TITLE
Fix points

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ line_length = 119
 
 [tool.pylint.format]
 max-line-length = "120"
+disable=["logging-fstring-interpolation"]
 
 [tool.pylint.'TYPECHECK']
 generated-members=['numpy.*', 'np.*']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,6 @@ use_parentheses = true
 ensure_newline_before_comments = true
 line_length = 119
 
-[tool.pylint.messages_control]
-disable = "C0330, C0326"
-
 [tool.pylint.format]
 max-line-length = "120"
 

--- a/slidescore_api/api.py
+++ b/slidescore_api/api.py
@@ -75,7 +75,7 @@ class SlideScoreResult:
         self.tma_sample_id = slide_dict["tmaSampleID"] if "tmaSampleID" in slide_dict else ""
         self.question = slide_dict["question"]
         self.answer = slide_dict["answer"]
-        self.lastModifiedOn = slide_dict["lastModifiedOn"]
+        self.last_modified_on = slide_dict["lastModifiedOn"]
 
         self.points = None
         if self.answer is not None and self.answer[:2] == "[{":
@@ -100,7 +100,7 @@ class SlideScoreResult:
         ret = str(self.image_id) + "\t" + self.image_name + "\t" + self.user + "\t"
         if self.tma_row is not None:
             ret = ret + str(self.tma_row) + "\t" + str(self.tma_col) + "\t" + self.tma_sample_id + "\t"
-        ret = ret + self.question + "\t" + self.answer + "\t" + self.lastModifiedOn
+        ret = ret + self.question + "\t" + self.answer + "\t" + self.last_modified_on
         return ret
 
     def __repr__(self):
@@ -113,7 +113,7 @@ class SlideScoreResult:
             f"tma_sample_id={self.tma_sample_id}, "
             f"question={self.question}, "
             f"answer=length {len(self.answer)})"
-            f"lastModifiedOn={self.lastModifiedOn}, "
+            f"lastModifiedOn={self.last_modified_on}, "
         )
 
 

--- a/slidescore_api/api.py
+++ b/slidescore_api/api.py
@@ -64,6 +64,7 @@ class SlideScoreResult:
                 "tmaSampleID": None,
                 "question": None,
                 "answer": None,
+                "lastModifiedOn": None,
             }
 
         self.image_id = int(slide_dict["imageID"])
@@ -74,6 +75,7 @@ class SlideScoreResult:
         self.tma_sample_id = slide_dict["tmaSampleID"] if "tmaSampleID" in slide_dict else ""
         self.question = slide_dict["question"]
         self.answer = slide_dict["answer"]
+        self.lastModifiedOn = slide_dict["lastModifiedOn"]
 
         self.points = None
         if self.answer is not None and self.answer[:2] == "[{":
@@ -98,7 +100,7 @@ class SlideScoreResult:
         ret = str(self.image_id) + "\t" + self.image_name + "\t" + self.user + "\t"
         if self.tma_row is not None:
             ret = ret + str(self.tma_row) + "\t" + str(self.tma_col) + "\t" + self.tma_sample_id + "\t"
-        ret = ret + self.question + "\t" + self.answer
+        ret = ret + self.question + "\t" + self.answer + "\t" + self.lastModifiedOn
         return ret
 
     def __repr__(self):
@@ -111,6 +113,7 @@ class SlideScoreResult:
             f"tma_sample_id={self.tma_sample_id}, "
             f"question={self.question}, "
             f"answer=length {len(self.answer)})"
+            f"lastModifiedOn={self.lastModifiedOn}, "
         )
 
 

--- a/slidescore_api/api.py
+++ b/slidescore_api/api.py
@@ -461,11 +461,11 @@ class APIClient:
         """
         if self.base_url is None:
             raise RuntimeError
-
+        cookies: dict = {"t": self.cookie}
         response = requests.get(
             self.base_url + f"/{str(level)}/{str(x_coord)}_{str(y_coord)}.jpeg",
             stream=True,
-            cookies={"t": self.cookie},
+            cookies=cookies,
         )
         if response.status_code == 200:
             return Image.open(io.BytesIO(response.content))

--- a/slidescore_api/api.py
+++ b/slidescore_api/api.py
@@ -14,7 +14,6 @@ from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import requests
 from PIL import Image
-from PIL.Image import Image
 from requests import Response
 from tqdm import tqdm
 

--- a/slidescore_api/api.py
+++ b/slidescore_api/api.py
@@ -14,6 +14,7 @@ from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import requests
 from PIL import Image
+from PIL.Image import Image
 from requests import Response
 from tqdm import tqdm
 

--- a/slidescore_api/api.py
+++ b/slidescore_api/api.py
@@ -465,7 +465,7 @@ class APIClient:
         response = requests.get(
             self.base_url + f"/{str(level)}/{str(x_coord)}_{str(y_coord)}.jpeg",
             stream=True,
-            cookies=dict(t=self.cookie),
+            cookies={"t": self.cookie},
         )
         if response.status_code == 200:
             return Image.open(io.BytesIO(response.content))

--- a/slidescore_api/cli.py
+++ b/slidescore_api/cli.py
@@ -180,7 +180,6 @@ def download_labels(  # pylint: disable=too-many-arguments,too-many-locals,too-m
     study_id: int,
     save_dir: Path,
     output_type: str,
-    ann_type: list,
     email: Optional[str] = None,
     question: Optional[str] = None,
     disable_certificate_check: bool = False,
@@ -201,8 +200,6 @@ def download_labels(  # pylint: disable=too-many-arguments,too-many-locals,too-m
         Directory to save the labels to.
     output_type: str
         User defined output format in which the annotations need to be saved.
-    ann_type: list
-        User choice for the kind of annotation type that is needed.
     email: str, optional
         The author email/name as registered on SlideScore to download those specific annotations.
     question : str
@@ -243,7 +240,7 @@ def download_labels(  # pylint: disable=too-many-arguments,too-many-locals,too-m
             for curr_annotation in annotation_parser.from_iterable(
                 row_iterator, filter_author=email, filter_label=question
             ):
-                save_shapely(curr_annotation, save_dir=save_dir, filter_type=ann_type)
+                save_shapely(curr_annotation, save_dir=save_dir)
         else:
             raise RuntimeError(f"Output type {output_type} not supported.")
 
@@ -268,7 +265,6 @@ def _download_labels(args: argparse.Namespace) -> None:
         args.study_id,
         args.output_dir,
         output_type=args.output_type,
-        ann_type=args.ann_type,
         question=args.question,
         email=args.user,
         disable_certificate_check=args.disable_certificate_check,
@@ -394,9 +390,6 @@ def register_parser(parser: argparse._SubParsersAction):
         type=str,
         choices=LabelOutputType.__members__,
         default="GEOJSON",
-    )
-    download_label_parser.add_argument(
-        "ann_type", nargs="*", type=str, help="list of required type of annotations", default=["brush", "polygon"]
     )
     download_label_parser.add_argument(
         "output_dir",

--- a/slidescore_api/cli.py
+++ b/slidescore_api/cli.py
@@ -34,7 +34,7 @@ class LabelOutputType(Enum):
 
     JSON: str = "json"
     RAW: str = "raw"
-    SHAPELY: str = "shapely"
+    GEOJSON: str = "geojson"
 
 
 def parse_api_token(data: Optional[Path] = None) -> str:
@@ -236,7 +236,7 @@ def download_labels(  # pylint: disable=too-many-arguments,too-many-locals,too-m
             with open(save_dir / "annotations.txt", "a", encoding="utf-8") as file:
                 for annotation in annotations:
                     file.write(annotation.to_row() + "\n")
-        elif LabelOutputType[output_type] == LabelOutputType.SHAPELY:
+        elif LabelOutputType[output_type] == LabelOutputType.GEOJSON:
             annotation_parser = SlideScoreAnnotations()
             row_iterator = _row_iterator(annotations)
 
@@ -390,10 +390,10 @@ def register_parser(parser: argparse._SubParsersAction):
     download_label_parser.add_argument(
         "-o" "--output-type",
         dest="output_type",
-        help="Type of output",
+        help="Type of output. GeoJSON is a compliant GeoJSON output.",
         type=str,
         choices=LabelOutputType.__members__,
-        default="SHAPELY",
+        default="GEOJSON",
     )
     download_label_parser.add_argument(
         "ann_type", nargs="*", type=str, help="list of required type of annotations", default=["brush", "polygon"]

--- a/slidescore_api/cli.py
+++ b/slidescore_api/cli.py
@@ -384,7 +384,8 @@ def register_parser(parser: argparse._SubParsersAction):
         required=False,
     )
     download_label_parser.add_argument(
-        "-o" "--output-type",
+        "-o",
+        "--output-type",
         dest="output_type",
         help="Type of output. GeoJSON is a compliant GeoJSON output.",
         type=str,

--- a/slidescore_api/utils/annotations.py
+++ b/slidescore_api/utils/annotations.py
@@ -19,6 +19,7 @@ class GeoJsonDict(TypedDict):
     """
     TypedDict for standard GeoJSON output
     """
+
     type: str
     lastModifiedOn: str
     features: List[Any]

--- a/slidescore_api/utils/annotations.py
+++ b/slidescore_api/utils/annotations.py
@@ -53,7 +53,7 @@ class AnnotationType(Enum):
     POINTS: str = "points"
 
 
-def _to_geojson_format(list_of_points: list, lastModifiedOn: str, answers: dict, label: str) -> GeoJsonDict:
+def _to_geojson_format(list_of_points: list, last_modified_on: str, answers: dict, label: str) -> GeoJsonDict:
     """
     Convert a given list of annotations into the GeoJSON standard.
 
@@ -69,7 +69,7 @@ def _to_geojson_format(list_of_points: list, lastModifiedOn: str, answers: dict,
 
     feature_collection: GeoJsonDict = {
         "type": "FeatureCollection",
-        "lastModifiedOn": lastModifiedOn,
+        "lastModifiedOn": last_modified_on,
         "features": [],
     }
 
@@ -140,7 +140,7 @@ def save_shapely(annotations: ImageAnnotation, save_dir: Path) -> None:
                 output += [entity for entity in data.geoms if entity.area > 0]
 
         feature_collection = _to_geojson_format(
-            output, lastModifiedOn=annotations.lastModifiedOn, answers=annotations.answers, label=annotations.label
+            output, last_modified_on=annotations.lastModifiedOn, answers=annotations.answers, label=annotations.label
         )
         json.dump(feature_collection, file, indent=2)
 

--- a/slidescore_api/utils/annotations.py
+++ b/slidescore_api/utils/annotations.py
@@ -385,11 +385,11 @@ class SlideScoreAnnotations:
         return self._annotated_images
 
     def from_iterable(
-            self,
-            row_iterator: Iterable,
-            filter_author: str = None,
-            filter_label: str = None,
-            filter_empty=True,
+        self,
+        row_iterator: Iterable,
+        filter_author: str = None,
+        filter_label: str = None,
+        filter_empty=True,
     ) -> Iterable:
         """
         Function to convert slidescore annotations (txt file) to an iterable.

--- a/slidescore_api/utils/annotations.py
+++ b/slidescore_api/utils/annotations.py
@@ -193,7 +193,7 @@ def _parse_brush_annotation(annotations: Dict) -> Dict:
             f"Polygons:"
             f"{[list(negative_polygons[idx].exterior.coords) for idx, val in used_negatives.items() if not val]}.\n"
             f"Areas   :{[negative_polygons[nidx].area for nidx, val in used_negatives.items() if not val]}.\n"
-        )
+        )  # disable=logging-fstring-interpolation
 
     points = MultiPolygon(polygons)
     data = {
@@ -385,11 +385,11 @@ class SlideScoreAnnotations:
         return self._annotated_images
 
     def from_iterable(
-        self,
-        row_iterator: Iterable,
-        filter_author: str = None,
-        filter_label: str = None,
-        filter_empty=True,
+            self,
+            row_iterator: Iterable,
+            filter_author: str = None,
+            filter_label: str = None,
+            filter_empty=True,
     ) -> Iterable:
         """
         Function to convert slidescore annotations (txt file) to an iterable.

--- a/slidescore_api/utils/annotations.py
+++ b/slidescore_api/utils/annotations.py
@@ -16,6 +16,9 @@ logger = logging.getLogger(__name__)
 
 
 class GeoJsonDict(TypedDict):
+    """
+    TypedDict for standard GeoJSON output
+    """
     type: str
     lastModifiedOn: str
     features: List[Any]

--- a/slidescore_api/utils/annotations.py
+++ b/slidescore_api/utils/annotations.py
@@ -112,7 +112,7 @@ def save_shapely(annotations: ImageAnnotation, save_dir: Path) -> None:
     ----------
     None
     """
-    save_path = save_dir / annotations.author / annotations.ImageID / annotations.slide_name
+    save_path = save_dir / annotations.author / annotations.ImageID
     save_path.mkdir(parents=True, exist_ok=True)
     with open(save_path / (annotations.label + ".json"), "w", encoding="utf-8") as file:
         dump_list: list = []

--- a/slidescore_api/utils/annotations.py
+++ b/slidescore_api/utils/annotations.py
@@ -45,6 +45,16 @@ class AnnotationType(Enum):
 
 
 def _to_geojson_format(list_of_points: list, label: str) -> Dict:
+    """
+    Convert a given list of annotations into the GeoJSON standard.
+
+    Parameters
+    ----------
+    list_of_points: list
+        A list containing annotation shapes or coordinates.
+    label: str
+        The string identifying the annotation class.
+    """
     feature_collection = {"type": "FeatureCollection"}
     features = []
     properties = {

--- a/slidescore_api/utils/annotations.py
+++ b/slidescore_api/utils/annotations.py
@@ -21,7 +21,7 @@ class ImageAnnotation(NamedTuple):
 
     This class can be instantiated to contain different attributes of a WSI along with its annotations.
     """
-
+    ImageID: int
     slide_name: str
     author: str
     label: str
@@ -65,15 +65,13 @@ def _to_geojson_format(list_of_points: list, label: str) -> Dict:
     }
     idx = 0
     for data in list_of_points:
-        features.append(
-            {"id": str(idx), "type": "Feature", "properties": properties, "geometry": mapping(data)}
-        )
+        features.append({"id": str(idx), "type": "Feature", "properties": properties, "geometry": mapping(data)})
         idx += 1
     feature_collection.update({"features": features})
     return feature_collection
 
 
-def save_shapely(annotations: ImageAnnotation, save_dir: Path, filter_type: list) -> None:
+def save_shapely(annotations: ImageAnnotation, save_dir: Path) -> None:
     """
     Given a single Annotation of a WSI, this function writes them as shapely objects to disc
     Parameters
@@ -84,14 +82,11 @@ def save_shapely(annotations: ImageAnnotation, save_dir: Path, filter_type: list
     save_dir: Path
         A Path object pointing to the directory where the shapely objects need to be written.
 
-    filter_type: list
-        List of annotation types that is to be written to disc. members must be enumerated in AnnotationType
-
     Returns
     ----------
     None
     """
-    save_path = save_dir / annotations.author / annotations.slide_name
+    save_path = save_dir / annotations.author / annotations.slide_name #/user-defined-folder/author_name/slidescore_id/annotation_label.json
     save_path.mkdir(parents=True, exist_ok=True)
     with open(save_path / (annotations.label + ".json"), "w", encoding="utf-8") as file:
         dump_list: list = []
@@ -403,6 +398,7 @@ class SlideScoreAnnotations:
             _row, data = _return
 
             row_annotation = ImageAnnotation(
+                ImageID=_row["ImageID"],
                 slide_name=_row["Image Name"],
                 author=_row["By"],
                 label=_row["Question"],

--- a/slidescore_api/utils/annotations.py
+++ b/slidescore_api/utils/annotations.py
@@ -193,7 +193,7 @@ def _parse_brush_annotation(annotations: Dict) -> Dict:
             f"Polygons:"
             f"{[list(negative_polygons[idx].exterior.coords) for idx, val in used_negatives.items() if not val]}.\n"
             f"Areas   :{[negative_polygons[nidx].area for nidx, val in used_negatives.items() if not val]}.\n"
-        )  # disable=logging-fstring-interpolation
+        )  # pylint:disable=logging-fstring-interpolation
 
     points = MultiPolygon(polygons)
     data = {

--- a/slidescore_api/utils/annotations.py
+++ b/slidescore_api/utils/annotations.py
@@ -101,7 +101,7 @@ def _to_geojson_format(list_of_points: list, last_modified_on: str, answers: dic
     return feature_collection
 
 
-def save_shapely(annotations: ImageAnnotation, save_dir: Path) -> None:
+def save_shapely(annotations: ImageAnnotation, save_dir: Path) -> None:  # pylint:disable=logging-fstring-interpolation
     """
     Given a single Annotation of a WSI, this function writes them as shapely objects to disc
     Parameters
@@ -149,7 +149,7 @@ def save_shapely(annotations: ImageAnnotation, save_dir: Path) -> None:
         json.dump(feature_collection, file, indent=2)
 
 
-def _parse_brush_annotation(annotations: Dict) -> Dict:
+def _parse_brush_annotation(annotations: Dict) -> Dict:  # pylint:disable=logging-fstring-interpolation
     """
 
     Parameters
@@ -193,7 +193,7 @@ def _parse_brush_annotation(annotations: Dict) -> Dict:
             f"Polygons:"
             f"{[list(negative_polygons[idx].exterior.coords) for idx, val in used_negatives.items() if not val]}.\n"
             f"Areas   :{[negative_polygons[nidx].area for nidx, val in used_negatives.items() if not val]}.\n"
-        )  # pylint:disable=logging-fstring-interpolation
+        )
 
     points = MultiPolygon(polygons)
     data = {
@@ -203,7 +203,7 @@ def _parse_brush_annotation(annotations: Dict) -> Dict:
     return data
 
 
-def _parse_polygon_annotation(annotations: Dict) -> Dict:
+def _parse_polygon_annotation(annotations: Dict) -> Dict:  # pylint:disable=logging-fstring-interpolation
     """
 
     Parameters
@@ -385,11 +385,11 @@ class SlideScoreAnnotations:
         return self._annotated_images
 
     def from_iterable(
-        self,
-        row_iterator: Iterable,
-        filter_author: str = None,
-        filter_label: str = None,
-        filter_empty=True,
+            self,
+            row_iterator: Iterable,
+            filter_author: str = None,
+            filter_label: str = None,
+            filter_empty=True,
     ) -> Iterable:
         """
         Function to convert slidescore annotations (txt file) to an iterable.

--- a/slidescore_api/utils/annotations.py
+++ b/slidescore_api/utils/annotations.py
@@ -7,7 +7,7 @@ import logging
 import warnings
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Iterable, NamedTuple, Union, List, TypedDict
+from typing import Any, Dict, Iterable, List, NamedTuple, TypedDict, Union
 
 import numpy as np
 from shapely.geometry import MultiPoint, MultiPolygon, Point, Polygon, box, mapping

--- a/slidescore_api/utils/annotations.py
+++ b/slidescore_api/utils/annotations.py
@@ -7,12 +7,18 @@ import logging
 import warnings
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Iterable, NamedTuple, Union, List
+from typing import Any, Dict, Iterable, NamedTuple, Union, List, TypedDict
 
 import numpy as np
 from shapely.geometry import MultiPoint, MultiPolygon, Point, Polygon, box, mapping
 
 logger = logging.getLogger(__name__)
+
+
+class GeoJsonDict(TypedDict):
+    type: str
+    lastModifiedOn: str
+    features: List[Any]
 
 
 class ImageAnnotation(NamedTuple):
@@ -47,7 +53,7 @@ class AnnotationType(Enum):
     POINTS: str = "points"
 
 
-def _to_geojson_format(list_of_points: list, lastModifiedOn: str, answers: dict, label: str) -> Dict[str, str]:
+def _to_geojson_format(list_of_points: list, lastModifiedOn: str, answers: dict, label: str) -> GeoJsonDict:
     """
     Convert a given list of annotations into the GeoJSON standard.
 
@@ -60,9 +66,15 @@ def _to_geojson_format(list_of_points: list, lastModifiedOn: str, answers: dict,
     label: str
         The string identifying the annotation class.
     """
-    feature_collection = {"type": "FeatureCollection", "lastModifiedOn": lastModifiedOn}
-    features: List = []
-    properties = {
+
+    feature_collection: GeoJsonDict = {
+        "type": "FeatureCollection",
+        "lastModifiedOn": lastModifiedOn,
+        "features": [],
+    }
+
+    features: List[Any] = []
+    properties: Dict[str, Union[str, Dict[str, str]]] = {
         "object_type": "annotation",
         "classification": {
             "name": label,
@@ -81,7 +93,7 @@ def _to_geojson_format(list_of_points: list, lastModifiedOn: str, answers: dict,
             }
         )
         idx += 1
-    feature_collection.update({"features": features})
+    feature_collection["features"] = features
     return feature_collection
 
 

--- a/slidescore_api/utils/annotations.py
+++ b/slidescore_api/utils/annotations.py
@@ -44,7 +44,7 @@ class AnnotationType(Enum):
     POINTS: str = "points"
 
 
-def _to_geojson_format(list_of_points: list, label: str) -> Dict:
+def _to_geojson_format(list_of_points: list, slide_name: str, label: str) -> Dict:
     """
     Convert a given list of annotations into the GeoJSON standard.
 
@@ -52,10 +52,12 @@ def _to_geojson_format(list_of_points: list, label: str) -> Dict:
     ----------
     list_of_points: list
         A list containing annotation shapes or coordinates.
+    slide_name: str
+        The slide name
     label: str
         The string identifying the annotation class.
     """
-    feature_collection = {"type": "FeatureCollection"}
+    feature_collection = {"type": "FeatureCollection", "slide_name": slide_name}
     features = []
     properties = {
         "object_type": "annotation",
@@ -86,7 +88,7 @@ def save_shapely(annotations: ImageAnnotation, save_dir: Path) -> None:
     ----------
     None
     """
-    save_path = save_dir / annotations.author / annotations.slide_name #/user-defined-folder/author_name/slidescore_id/annotation_label.json
+    save_path = save_dir / annotations.author / annotations.ImageID
     save_path.mkdir(parents=True, exist_ok=True)
     with open(save_path / (annotations.label + ".json"), "w", encoding="utf-8") as file:
         dump_list: list = []
@@ -113,7 +115,7 @@ def save_shapely(annotations: ImageAnnotation, save_dir: Path) -> None:
             for data in dump_list:
                 output += [_ for _ in data.geoms if _.area > 0]
 
-        feature_collection = _to_geojson_format(output, label=annotations.label)
+        feature_collection = _to_geojson_format(output, slide_name=annotations.slide_name, label=annotations.label)
         json.dump(feature_collection, file, indent=2)
 
 

--- a/slidescore_api/utils/annotations.py
+++ b/slidescore_api/utils/annotations.py
@@ -73,18 +73,21 @@ def save_shapely(annotations: ImageAnnotation, save_dir: Path, filter_type: list
     save_path.mkdir(parents=True, exist_ok=True)
     with open(save_path / (annotations.label + ".json"), "w", encoding="utf-8") as file:
         dump_list: list = []
-        for polygon_id, _ in enumerate(annotations.annotation):
+        for ann_id, _ in enumerate(annotations.annotation):
             # Handles only polygon and brush type annotations.
             # rects are internally polygons
-            is_polygon = AnnotationType[annotations.annotation[polygon_id]["type"].upper()] in (
+            annotation_type = AnnotationType[annotations.annotation[ann_id]["type"].upper()]
+            is_polygon = annotation_type in (
                 AnnotationType.POLYGON,
                 AnnotationType.BRUSH,
-                AnnotationType.RECT,
+                # AnnotationType.RECT,
             )
-            if is_polygon:
-                is_valid = len(annotations.annotation[polygon_id]["points"]) > 0
-                if is_valid:
-                    dump_list.append(mapping(annotations.annotation[polygon_id]["points"]))
+            points = annotations.annotation[ann_id]["points"]
+            if is_polygon or annotation_type == AnnotationType.POINTS:
+                if len(points) > 0:
+                    dump_list.append(mapping(points))
+            else:
+                raise RuntimeError(f"Annotation type {annotation_type} is not supported.")
 
         json.dump(dump_list, file, indent=2)
 

--- a/slidescore_api/utils/annotations.py
+++ b/slidescore_api/utils/annotations.py
@@ -74,7 +74,6 @@ def save_shapely(annotations: ImageAnnotation, save_dir: Path, filter_type: list
     save_path.mkdir(parents=True, exist_ok=True)
     with open(save_path / (annotations.label + ".json"), "w", encoding="utf-8") as file:
         dump_list: list = []
-        is_polygon = None
         for ann_id, _ in enumerate(annotations.annotation):
             # Handles only polygon and brush type annotations.
             # rects are internally polygons
@@ -97,9 +96,11 @@ def save_shapely(annotations: ImageAnnotation, save_dir: Path, filter_type: list
 
         output = []
         for data in dump_list:
-            output += list(data)
+            output += data.geoms
 
-        json.dump(json.loads(gpd.GeoSeries(output).to_json()), file, indent=2)
+        json.dump(
+            json.loads(gpd.GeoDataFrame({"geometry": output, "name": annotations.label}).to_json()), file, indent=2
+        )
 
 
 def _parse_brush_annotation(annotations: Dict) -> Dict:


### PR DESCRIPTION
Fixes #20 #17 

Following changes/improvements are done in this PR.
1. The api can handle any type of annotations (rect, point, etc)
2. Now, annotations can be saved in the GeoJSON format. This allows users to use the annotations downloaded using the api with third-party visualization tools like QuPath. 