### PR TITLE
Uploads MultiPolygons through the slidescore-api 

### DIFF
--- a/slidescore_api/cli.py
+++ b/slidescore_api/cli.py
@@ -85,6 +85,12 @@ def _shapely_to_slidescore(shapely_object):
     elif shapely_type == shapely.geometry.Point:
         output = [{"x": int(shapely_object.x), "y": int(shapely_object.y)}]
 
+    elif shapely_type == shapely.geometry.MultiPolygon:
+        output = []
+        for shape in shapely_object.geoms:
+            shape_coords = [{"x": int(x), "y": int(y)} for x, y in shape.exterior.coords]
+            output.append({"type": "polygon", "points": shape_coords})
+
     else:
         raise NotImplementedError
 

--- a/slidescore_api/utils/annotations.py
+++ b/slidescore_api/utils/annotations.py
@@ -187,8 +187,10 @@ def _parse_brush_annotation(annotations: Dict) -> Dict:  # pylint:disable=loggin
             f"{[list(negative_polygons[idx].exterior.coords) for idx, val in used_negatives.items() if not val]}.\n"
             f"Areas   :{[negative_polygons[nidx].area for nidx, val in used_negatives.items() if not val]}.\n"
         )
-
-    points = MultiPolygon(polygons)
+    if len(polygons) == 1:
+        points = Polygon(polygons)
+    else:
+        points = MultiPolygon(polygons)
     data = {
         "type": "brush",
         "points": points,
@@ -213,8 +215,7 @@ def _parse_polygon_annotation(annotations: Dict) -> Dict:  # pylint:disable=logg
     if len(points) < 3:
         logger.warning(f"Invalid polygon: {annotations}")
         points = []
-
-    points = MultiPolygon([Polygon(points)])
+    points = Polygon(points)
     data = {
         "type": "polygon",
         "points": points,


### PR DESCRIPTION
Fixes #32

Now, we can upload `MultiPolygons` saved in geojson format from local machines to slidescore.

Notes:

1. Please bear in mind since Slidescore expects annotations to be Polygons, we unroll MultiPolygons into multiple Polygons.

2. If the annotations are overlapping (which is handled easily by MultiPolygon), there maybe some mistakes while rendering annotations from such a file. See below for example:

I tried downloading existing annotations from slidescore and uploading them back. 
This is for study ID = 642, Image ID= 86175. The annotation user is j.teuwen@nki.nl

The image and its original annotation on slidescore before I download the annotations:
![image](https://user-images.githubusercontent.com/26798611/191965223-64184da1-96bf-4aa3-a767-b24d239b6ec0.png)

After uploading the same annotation using the fixes pushed in this PR, we get the following image one slidescore
![image](https://user-images.githubusercontent.com/26798611/191971012-1193de5d-1044-47e2-8995-d0c310a6c314.png)

The annotations in the middle have disappeared.

Before            |  After
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/26798611/191971158-8336e91e-cebd-4c7f-9a79-942d4f2cb18f.png)  |  ![image](https://user-images.githubusercontent.com/26798611/191971206-365df5ea-9a75-4db1-8f43-34024781769e.png)

It turns out that the annotation was a little noisy in that region where the polygon overlaps with itself. I corrected the annotation and removed that overlap.
Before            |  After
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/26798611/191971348-6450a775-6573-4a9c-91ef-7f7df2eade4d.png) | ![image](https://user-images.githubusercontent.com/26798611/191971627-21dde163-1dbe-4099-9a2d-53f55112eafa.png)

After redownloading the annotation file and uploading it, all problems vanished. Although the total number of shapes are now shown as 4 on the information panel of slidescore on the left. 

![image](https://user-images.githubusercontent.com/26798611/191971698-85595d55-14fd-4761-8b39-393f30021bb1.png)

So, double-check all your annotations.