### PR TITLE
add slidescore url and slidescore study id to download manifest.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
       name: isort (pyi)
       types: [pyi]
 -   repo: https://github.com/psf/black
-    rev: 21.6b0
+    rev: 22.3.0
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -1,4 +1,52 @@
 # coding=utf-8
 # Placeholder
-def test_test():
-    assert True
+"""
+Unit tests
+"""
+
+# pylint: disable=duplicate-code
+
+import json
+from pathlib import Path
+
+from slidescore_api.cli import append_to_manifest
+
+
+def test_append_to_manifest():
+    # Ignores similar lines
+    """
+    Tests the function of slidescore_api.cli.append_to_manifest
+    """
+    if Path("./test_append_to_manifest/download_config.json").is_file():
+        Path("./test_append_to_manifest/download_config.json").unlink()  # Remove file
+
+    append_to_manifest(
+        save_dir=Path("./test_append_to_manifest"), keys=["slidescore_url", "1234", "slidescore_url"], value="https"
+    )  # -> {"slidescore_url": {"1234": {"slidescore_url": "https}}}
+
+    append_to_manifest(
+        save_dir=Path("./test_append_to_manifest"), keys=["slidescore_url", "1234", "slidescore_id"], value=1234
+    )  # -> {"slidescore_url": {"1234": {"slidescore_url": "https, "slidescore_id": 1234}}}
+
+    append_to_manifest(
+        save_dir=Path("./test_append_to_manifest"), keys=["slidescore_url", "1234", "mapping", "pathname"], value=1234
+    )
+    # -> {"slidescore_url": {"1234": {"slidescore_url": "https, "slidescore_id": 1234,
+    # "mapping": {"pathname": 1234} }}}
+
+    expected_object = {
+        "slidescore_url": {"1234": {"slidescore_url": "https", "slidescore_id": 1234, "mapping": {"pathname": 1234}}}
+    }
+
+    with open("./test_append_to_manifest/download_config.json", "r", encoding="utf-8") as file:
+        obj = json.load(file)
+        assert (
+            obj == expected_object
+        ), f"expected object is {expected_object}, while the actual object on disk is {obj}"
+
+    Path("./test_append_to_manifest/download_config.json").unlink()  # Remove file
+    Path("./test_append_to_manifest").rmdir()  # Remove dir
+
+
+if __name__ == "__main__":
+    test_append_to_manifest()


### PR DESCRIPTION
- save manifest as json
- when starting the download, add slidescore_url and slidescore_study_id
- add layer of slidescore_url and slidescore_study_id keys, might a user download multiple studies into a single directory, so as to not overwrite the initial values of `slidescore_study_id` if a second study is downloaded to the same directory.

Fixes #40 
