### PR TITLE
#48 fix slidescore api crash

### DIFF
--- a/slidescore_api/cli.py
+++ b/slidescore_api/cli.py
@@ -412,7 +412,9 @@ def download_wsis(
     # Download and save WSIs
     for image in tqdm(images):
         image_id = image["id"]
-
+        if (save_dir / image_id).exists():
+            logger.info("Skipping: image id folder already exists: %s", image_id)
+            continue
         logger.info("Downloading image for id: %s", image_id)
         filename = client.download_slide(study_id, image, save_dir=save_dir)
         logger.info("Image with id %s has been saved to %s.", image_id, filename)


### PR DESCRIPTION
Fixes #48 

This quick fix skips existing image_id folders to reduce the number of requests. However, if an error occurs during an image download, subsequent retries will also skip these folders because they already exist. Consequently, these folders must be manually deleted before attempting another download. A comprehensive fix would likely require modifying the way download history is tracked, which could disrupt the current history files of already downloaded folders.


